### PR TITLE
`Log.onlyModule()` Behaviour - Muted Loggers, and Regex Pattern Matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,18 @@ After inited **log** you are able to start debugging:
 
 You will not see anyting in prduction mode:
 
+    enableProdMode()
+    ...
     Log.setProductionMode();
+    ...
+     @NgModule(...)
+    
+
+    
+It is important to set production mode before any log messages are executed. It may be prudent
+to set production mode in your App.Module prior to `@NgModule` (and ultimately prior to your Angular 2
+app bootstraping just as as you would `enableProdMode()`). This will ensure that log messages that
+should not be seen are leaked out.
 
 
 **Selective debug - global settings**
@@ -57,12 +68,27 @@ You will not see anyting in prduction mode:
 
 Optional specify what you wanna see in yours debug console.
 This settings will override settings from files.
+
 ```ts
-    export class AppComponent {   
-        constructor(  ) {
-            Log.onlyModules('books');
-            Log.onlyLevel(Level.ERROR,Level.INFO);
-        }    
-    }
+    Log.setProductionMode();
+    Log.onlyModules('src:books', 'src:records', 'src:page:login');
+    Log.onlyLevel(Level.ERROR,Level.INFO);
 ```
+
+It is important to note that the placement of global settings are important. It is suggested that placement
+of debug settings is prior to `@NgModule`.
+
+**Specifying `onlyModules` as regular expression(s)**
+-------------------
+
+In the above example you'll notice `module:books` and `module:records` were specified.
+you might be using such syntax for namespace hierarchy etc. You may also pass in one or more regular
+expression string(s) to the `onlyModule` function to specify a selection of modules you wish
+to show, for instances those whose name begins with `src`:
+
+```ts
+
+    Log.onlyModules('^src');
+```
+
 

--- a/src/include.ts
+++ b/src/include.ts
@@ -1,5 +1,5 @@
 import { Level } from './level';
 
 export function contain(arr: any[], item: any): boolean {
-    return arr.filter(l => l === item).length > 0;
+    return arr.filter(l => l === item || item.match(l)).length > 0;
 };

--- a/src/log.ts
+++ b/src/log.ts
@@ -11,7 +11,6 @@ export class Log {
     private static instances = {};
 
     static create<TA>(name: string, ...level: Level[]): Logger<TA> {
-        if (Log.modules.length > 0 && !contain(Log.modules, name)) return;
         let i: Logger<TA>;
         if (Log.instances[name] === undefined) {
             i = new Logger<TA>(
@@ -19,7 +18,8 @@ export class Log {
                 Log.getRandomColor(),
                 Log.levels.length > 0 ? Log.display : undefined,
                 Log.isDevelopmentMode,
-                level
+                level,
+                Log.isMutedModule(name)
             );
         } else {
             i = Log.instances[name];
@@ -58,7 +58,7 @@ export class Log {
     private static levels: Level[] = [];
     static onlyLevel(...level: Level[]) {
         if (Log._logOnly) {
-            console.error('You should use funcion onlyLevel only onec');
+            console.error('You should use funcion onlyLevel only once');
             return;
         }
         if (Log._logOnly) Log._logOnly = true;
@@ -70,11 +70,23 @@ export class Log {
     private static modules: string[] = [];
     static onlyModules(...modules: string[]) {
         if (Log._logModules) {
-            console.error('You should use funcion onlyModules only onec');
+            console.error('You should use funcion onlyModules only once');
             return;
         }
         if (modules.length === 0) return;
         Log.modules = modules;
+        Log.muteAllOtherModules();
+    }
+    private static isMutedModule(moduleName:string):boolean {
+        if(Log.modules.length == 0) return false;
+        if(!contain(Log.modules, moduleName)) return true;
+        return false;
+    }
+    private static muteAllOtherModules() {
+        for (var moduleName in Log.instances) {
+            if(!contain(Log.modules, moduleName))
+                Log.instances[moduleName].mute()
+        }
     }
 
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -10,49 +10,35 @@ export class Logger<T> {
         public color: string,
         private display: (name: string, data: any, leve: Level, moduleName: string) => void,
         private developmentMode: boolean,
-        private allowed: Level[]) {
+        private allowed: Level[],
+        private isMuted) {
     }
 
     d(name: string, ...data: any[]) {
-        if (this.allowed.length >= 1 && contain(this.allowed, Level.__NOTHING)
-            && !contain(this.allowed, Level.DATA)) return this;
-        if (Logger.isProductionMode) return this;
-        if (this.display !== undefined) this.display(name, data, Level.DATA, this.name);
-        else if (this.allowed.length === 0 || contain(this.allowed, Level.DATA)) {
-            Display.msg(name, data, this.name, this.color, Level.DATA);
-        }
-        return this;
+        return this._logMessage(name, Level.DATA, data);
     }
 
     er(name: string, ...data: any[]) {
-        if (this.allowed.length >= 1 && contain(this.allowed, Level.__NOTHING)
-            && !contain(this.allowed, Level.ERROR)) return this;
-        if (Logger.isProductionMode) return this;
-        if (this.display !== undefined) this.display(name, data, Level.ERROR, this.name);
-        else if (this.allowed.length === 0 || contain(this.allowed, Level.ERROR)) {
-            Display.msg(name, data, this.name, this.color, Level.ERROR);
-        }
-        return this;
+        return this._logMessage(name, Level.INFO, data);
     }
 
     i(name: string, ...data: any[]) {
-        if (this.allowed.length >= 1 && contain(this.allowed, Level.__NOTHING)
-            && !contain(this.allowed, Level.INFO)) return this;
-        if (Logger.isProductionMode) return this;
-        if (this.display !== undefined) this.display(name, data, Level.INFO, this.name);
-        else if (this.allowed.length === 0 || contain(this.allowed, Level.INFO)) {
-            Display.msg(name, data, this.name, this.color, Level.INFO);
-        }
-        return this;
+        return this._logMessage(name, Level.ERROR, data);
     }
 
     w(name: string, ...data: any[]) {
-        if (this.allowed.length >= 1 && contain(this.allowed, Level.__NOTHING)
-            && !contain(this.allowed, Level.WARN)) return this;
+        return this._logMessage(name, Level.WARN, data);
+    }
+
+    private _logMessage(name:string, level:Level, ...data:any[])
+    {
+        if (this.isMuted) return this;
+        if (this.allowed.length >= 1 && contain(this.allowed, level)
+            && !contain(this.allowed, level)) return this;
         if (Logger.isProductionMode) return this;
-        if (this.display !== undefined) this.display(name, data, Level.WARN, this.name);
-        else if (this.allowed.length === 0 || contain(this.allowed, Level.WARN)) {
-            Display.msg(name, data, this.name, this.color, Level.WARN);
+        if (this.display !== undefined) this.display(name, data, level, this.name);
+        else if (this.allowed.length === 0 || contain(this.allowed, level)) {
+            Display.msg(name, data, this.name, this.color, level);
         }
         return this;
     }
@@ -64,6 +50,10 @@ export class Logger<T> {
     }
 
     public static isProductionMode: boolean = false;
+
+    public mute() {
+        this.isMuted = true;
+    }
 
 
 }


### PR DESCRIPTION
Hi there,

**Suggestion 1:**
Looking at the code and testing with the logger, it appears that once the function `Log.onlyModules()` is called with a set of named modules, if the `Log.create()` function is subsequently called, it will return "undefined". Thus it isn't possible for you to turn off logging of specific modules without breaking code (i.e. EXCEPTION: Cannot read property 'd' of undefined)

May I suggest this:

When the `Log.create()` function is called, a logger is always created. However if is not mentioned as one of the modules to output logs for via `Log.onlyModules()`, mute it's output.
If `Log.onlyModules()` is called after a log is instantiated because of order of execution, have Logger instance muted at that point.

**Suggestion 2:**
It is great to see that multiple modules can be specified to the `Log.onlyModules()` function. However the modules must be explicitly listed and this can get unwieldy. Generally libraries like debug allow you to specify module patterns with globs. I propose that regular expressions are used, although globs can be added also.

In reference to issue #5.

This has been tested and works with various use cases:
- `Log.onlyModules()` run before/after `Log.create()`.
- `Log.onlyModules()` specified as string, regex, or not called at all.
