### PR TITLE
"Renamed" functions for logging (d, er, i, w) to better match their purpose (data, error, warn, info)

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,7 +15,7 @@ export class Logger<T> {
         public fixedWidth: number) {
     }
 
-    d(name: string, ...data: any[]) {
+    private _data(name: string, ...data: any[]) {
         if (this.allowed.length >= 1 && contain(this.allowed, Level.__NOTHING)
             && !contain(this.allowed, Level.DATA)) return this;
         if (Logger.isProductionMode) return this;
@@ -26,7 +26,7 @@ export class Logger<T> {
         return this;
     }
 
-    er(name: string, ...data: any[]) {
+    private _error(name: string, ...data: any[]) {
         if (this.allowed.length >= 1 && contain(this.allowed, Level.__NOTHING)
             && !contain(this.allowed, Level.ERROR)) return this;
         if (Logger.isProductionMode) return this;
@@ -37,7 +37,7 @@ export class Logger<T> {
         return this;
     }
 
-    i(name: string, ...data: any[]) {
+    private _info(name: string, ...data: any[]) {
         if (this.allowed.length >= 1 && contain(this.allowed, Level.__NOTHING)
             && !contain(this.allowed, Level.INFO)) return this;
         if (Logger.isProductionMode) return this;
@@ -48,7 +48,7 @@ export class Logger<T> {
         return this;
     }
 
-    w(name: string, ...data: any[]) {
+    private _warn(name: string, ...data: any[]) {
         if (this.allowed.length >= 1 && contain(this.allowed, Level.__NOTHING)
             && !contain(this.allowed, Level.WARN)) return this;
         if (Logger.isProductionMode) return this;
@@ -59,8 +59,56 @@ export class Logger<T> {
         return this;
     }
 
-    private _logMessage(name:string, level:Level, ...data:any[])
-    {
+    /** @deprecated Use data(...) 
+     * @see data
+    */
+    d = (name: string, ...data: any[]) => this._data(name, data);
+
+    /** @deprecated Use error(...) 
+     * @see error
+    */
+
+    er = (name: string, ...data: any[]) => this._error(name, data);
+
+    /** @deprecated Use info(...) 
+     * @see info
+    */
+    i = (name: string, ...data: any[]) => this._info(name, data);
+
+    /** @deprecated Use warn(...) 
+     * @see warn
+    */
+    w = (name: string, ...data: any[]) => this._warn(name, data);
+
+    /**
+     * Logs message and data with the level=data
+     * @param message The message
+     * @param otherParams Additional parameters
+     */
+    data = (message: string, ...otherParams: any[]):Logger<T> => {return this._data(message, otherParams);};
+
+    /**
+     * Logs message and data with the level=error
+     * @param message The message
+     * @param otherParams Additional parameters
+     */
+    error = (message: string, ...otherParams: any[]) => this._error(message, otherParams);
+
+    /**
+     * Logs message and data with the level=info
+     * @param message The message
+     * @param otherParams Additional parameters
+     */
+    info = (message: string, ...otherParams: any[]) => this._info(message, otherParams);
+
+    /**
+     * Logs message and data with the level=warn
+     * @param message The message
+     * @param otherParams Additional parameters
+     */
+    warn = (message: string, ...otherParams: any[]) => this._warn(message, otherParams);
+
+    private _logMessage(name: string, level: Level, ...data: any[]) {
         if (this.isMuted) return this;
         if (this.allowed.length >= 1 && contain(this.allowed, level)
             && !contain(this.allowed, level)) return this;

--- a/src/test/test-class.ts
+++ b/src/test/test-class.ts
@@ -8,6 +8,8 @@ export class Book {
     contructor() {
         log.d('asdasd').er('asdasd', 'asdasd');
         log.er('asd', 'asd');
+        log.data('asdasd').error('asdasd', 'asdasd');
+        log.error('asd', 'asd');
     }
 
     getSomething() {


### PR DESCRIPTION
Added new **intuitively named functions**, and deprecated the existing ones so that **existing functionality is maintained** as follows:

- _d(...)_ becomes _data(...)_
- _er(...)_ becomes _error(...)_
- _i(...)_ becomes _info(...)_
- _w(...)_ becomes _warn(...)_